### PR TITLE
Explorer gear fix

### DIFF
--- a/maps/southern_cross/structures/closets/misc.dm
+++ b/maps/southern_cross/structures/closets/misc.dm
@@ -49,6 +49,7 @@
 		/obj/item/clothing/shoes/boots/winter/explorer,
 		/obj/item/clothing/gloves/black,
 		/obj/item/device/radio/headset/explorer,
+		/obj/item/device/radio/headset/explorer/alt,
 		/obj/item/device/flashlight,
 		/obj/item/device/gps/explorer,
 		/obj/item/weapon/storage/box/flare,


### PR DESCRIPTION
Adds missing standard gear to explorers lockers, like machete holsters and belts.